### PR TITLE
bugfix on glob_s3

### DIFF
--- a/ml_logger/ml_logger/ml_logger.py
+++ b/ml_logger/ml_logger/ml_logger.py
@@ -870,7 +870,7 @@ class ML_Logger:
         response = s3_client.list_objects(Bucket=bucket, Prefix=s3_prefix,
                                           MaxKeys=max_keys, **KWargs)
         files = []
-        for entry in response['Contents']:
+        for entry in response.get('Contents', []):
             filename = entry['Key'][truncate:]
             print(filename)
             if "*" in query_prefix:

--- a/ml_logger/ml_logger_tests/test_cloud.py
+++ b/ml_logger/ml_logger_tests/test_cloud.py
@@ -77,6 +77,8 @@ def test_s3_glob(setup):
     files = logger.glob_s3(s3_bucket + "/test_dir.tar")
     assert 'test_dir.tar' in files
 
+    files = logger.glob_s3(s3_bucket + "/this_does_not_exist")
+    assert not files
 
 def test_s3_glob_prefix(setup):
     import os


### PR DESCRIPTION
When the glob result is empty, response doesn't have key "Contents". Thus it results in KeyError.