### PR TITLE
Support `np.uint16` images

### DIFF
--- a/ml_logger/__init__.py
+++ b/ml_logger/__init__.py
@@ -9,7 +9,7 @@ from .caches.summary_cache import SummaryCache
 from .helpers.print_utils import PrintHelper
 from .log_client import LogClient
 from .ml_logger import USER, ROOT, logger, LOGGER_USER, ML_Logger, pJoin
-from .struts import ALLOWED_TYPES
+from .structs import ALLOWED_TYPES
 
 
 class RUN(PrefixProto):

--- a/ml_logger/log_client.py
+++ b/ml_logger/log_client.py
@@ -6,7 +6,7 @@ from io import BytesIO, StringIO
 from ml_logger.requests import SyncRequests
 from ml_logger.serdes import serialize, deserialize
 from ml_logger.server import LoggingServer
-from ml_logger.struts import ALLOWED_TYPES, LogEntry, LogOptions, LoadEntry, RemoveEntry, PingData, GlobEntry, \
+from ml_logger.structs import ALLOWED_TYPES, LogEntry, LogOptions, LoadEntry, RemoveEntry, PingData, GlobEntry, \
     MoveEntry, CopyEntry, MakeVideoEntry, ArchiveEntry, ShellEntry
 from requests_futures.sessions import FuturesSession
 

--- a/ml_logger/ml_logger.py
+++ b/ml_logger/ml_logger.py
@@ -1515,13 +1515,8 @@ class ML_Logger:
 
         value_low, value_high = value_range
 
-        if np.issubdtype(stack.dtype, np.uint8):
-            # FIXME: figure out what's going on here
-            assert not normalize, "normalization is not applicable to uint8 images"
-            assert (
-               stack.dtype == dtype,
-               f"stack dtype ({stack.dtype}) and save dtype ({dtype}) do not match"
-            )
+        if np.issubdtype(stack.dtype, dtype):
+            assert not normalize, f"normalization is not applicable to {dtype} images"
         elif len(stack.shape) == 3:
             # todo: change to always set shape to len(4), and check if dim[1] is 1.
             from matplotlib import cm

--- a/ml_logger/ml_logger.py
+++ b/ml_logger/ml_logger.py
@@ -1572,7 +1572,7 @@ class ML_Logger:
         else:
             raise RuntimeError(
                 f"{stack.shape} is not supported. `len(shape)` should be 3 "
-                "for grayscale or depth, and 4 for RGB(A)."
+                "for grayscale, and 4 for RGB(A)."
             )
 
         # this needs to be updated

--- a/ml_logger/ml_logger.py
+++ b/ml_logger/ml_logger.py
@@ -22,6 +22,7 @@ from .helpers.color_helpers import Color
 from .helpers.default_set import DefaultSet
 from .helpers.print_utils import PrintHelper
 from .log_client import LogClient
+from .structs import ALLOWED_TYPES
 
 # environment defaults
 CWD = os.getcwd()
@@ -1488,7 +1489,7 @@ class ML_Logger:
         return s3.download_file(bucket, object_name, to)
 
     def save_images(self, stack, key, n_rows=None, n_cols=None, cmap=None, normalize=None,
-                    value_range=(0, 1), background=1):
+                    value_range=(0, 1), background=1, dtype=np.uint8):
         """Log images as a composite of a grid. Images input as a 4-D stack.
 
         :param stack: Size(n, w, h, c)
@@ -1498,8 +1499,15 @@ class ML_Logger:
         :param cmap: OneOf([str, matplotlib.cm.ColorMap])
         :param normalize: defaul None. OneOf[None, 'individual', 'row', 'column', 'grid']. Only 'grid' and
                           'individual' are implemented.
+        :param dtype: dtype to use for the saved image.
         :return: None
         """
+        # Check dtype is supported by ml-logger
+        assert (
+            dtype in ALLOWED_TYPES,
+            f"Unsupported dtype: {dtype}. Supported types: {ALLOWED_TYPES}"
+        )
+
         stack = stack if hasattr(stack, 'dtype') else np.stack(stack)
 
         n_cols = n_cols or len(stack)
@@ -1508,7 +1516,12 @@ class ML_Logger:
         value_low, value_high = value_range
 
         if np.issubdtype(stack.dtype, np.uint8):
-            assert not normalize, "normalization is not applicable to unit8 images"
+            # FIXME: figure out what's going on here
+            assert not normalize, "normalization is not applicable to uint8 images"
+            assert (
+               stack.dtype == dtype,
+               f"stack dtype ({stack.dtype}) and save dtype ({dtype}) do not match"
+            )
         elif len(stack.shape) == 3:
             # todo: change to always set shape to len(4), and check if dim[1] is 1.
             from matplotlib import cm
@@ -1532,9 +1545,10 @@ class ML_Logger:
                 stack = (stack - low) / (r if r.all() else 1)
                 stack = stack * (value_high - value_low) + value_low
 
-            stack = (map_fn(stack.clip(value_low, value_high)) * 255).astype(np.uint8)
-            stack = stack.astype(np.uint8)
-
+            # Clip values after applying cmap
+            dtype_max_val = np.iinfo(dtype).max
+            stack = (map_fn(stack.clip(value_low, value_high)) * dtype_max_val)
+            stack = stack.astype(dtype)
         elif len(stack.shape) == 4:
             assert cmap is None, "color map is not used for rgb(a) images."
 
@@ -1556,17 +1570,24 @@ class ML_Logger:
                 stack = (stack - low) / (r if r.all() else 1)
                 stack = stack * (value_high - value_low) + value_low
 
-            stack = stack.clip(value_low, value_high) * 255
-            stack = stack.astype(np.uint8)
+            # Clip values
+            dtype_max_val = np.iinfo(dtype).max
+            stack = stack.clip(value_low, value_high) * dtype_max_val
+            stack = stack.astype(dtype)
         else:
-            raise RuntimeError(f"{stack.shape} is not supported. `len(shape)` should be 3 "
-                               f"for gray scale  and 4 for RGB(A).")
+            raise RuntimeError(
+                f"{stack.shape} is not supported. `len(shape)` should be 3 "
+                "for grayscale or depth, and 4 for RGB(A)."
+            )
 
         # this needs to be updated
-        assert np.issubdtype(stack.dtype, np.uint8), "the image type need to be unsigned 8-bit."
+        assert (
+            any(np.issubdtype(stack.dtype, t) for t in ALLOWED_TYPES),
+            f"the image type need to be one of {ALLOWED_TYPES}"
+        )
         n, h, w, *c = stack.shape
         # todo: add color background -- need to decide on which library to use.
-        composite = np.full([h * n_rows, w * n_cols, *c], background, dtype='uint8')
+        composite = np.full([h * n_rows, w * n_cols, *c], background, dtype=dtype)
         for i in range(n_rows):
             for j in range(n_cols):
                 k = i * n_cols + j

--- a/ml_logger/ml_logger.py
+++ b/ml_logger/ml_logger.py
@@ -1594,14 +1594,14 @@ class ML_Logger:
         self.client.send_image(key=pJoin(self.prefix, key), data=composite)
         return key
 
-    def save_image(self, image, key: str, cmap=None, normalize=None):
+    def save_image(self, image, key: str, cmap=None, normalize=None, dtype=np.uint8):
         """Log a single image.
 
         :param image: numpy object Size(w, h, 3)
         :param key: example: "figures/some_fig_name.png", the file key to which the
             image is saved.
         """
-        return self.save_images([image], key, n_rows=1, n_cols=1, cmap=cmap, normalize=normalize)
+        return self.save_images([image], key, n_rows=1, n_cols=1, cmap=cmap, normalize=normalize, dtype=dtype)
 
     def save_video(self, frame_stack, key, format=None, fps=20, **imageio_kwargs):
         """

--- a/ml_logger/server.py
+++ b/ml_logger/server.py
@@ -7,7 +7,7 @@ from typing import Sequence, Union
 
 from ml_logger.helpers import load_from_file
 from ml_logger.serdes import deserialize, serialize
-from ml_logger.struts import ALLOWED_TYPES, LogEntry, LogOptions, LoadEntry, RemoveEntry, \
+from ml_logger.structs import ALLOWED_TYPES, LogEntry, LogOptions, LoadEntry, RemoveEntry, \
     PingData, GlobEntry, MoveEntry, CopyEntry, MakeVideoEntry, ArchiveEntry, ShellEntry
 from termcolor import cprint
 

--- a/ml_logger/structs.py
+++ b/ml_logger/structs.py
@@ -79,4 +79,4 @@ Signal = namedtuple("Signal", ['exp_key', 'signal'])
 
 import numpy as np
 
-ALLOWED_TYPES = (np.uint8,)  # ONLY uint8 is supported.
+ALLOWED_TYPES = (np.uint8, np.uint16)  # ONLY uint8 and uint16 is supported.


### PR DESCRIPTION
Mostly so we can save the depth images from the RealSense which are in unsigned int16 grayscale.